### PR TITLE
Mention dialog reuse

### DIFF
--- a/client/src/Constants.js
+++ b/client/src/Constants.js
@@ -1,44 +1,4 @@
 /* Store constant values here */
-import React from "react";
-import SentimentVeryDissatisfiedOutlinedIcon from "@material-ui/icons/SentimentVeryDissatisfiedOutlined";
-import SentimentVeryDissatisfiedIcon from "@material-ui/icons/SentimentVeryDissatisfied";
-import SentimentDissatisfiedIcon from "@material-ui/icons/SentimentDissatisfied";
-import SentimentSatisfiedAltIcon from "@material-ui/icons/SentimentSatisfiedAlt";
-import SentimentVerySatisfiedIcon from "@material-ui/icons/SentimentVerySatisfied";
-import SentimentVerySatisfiedOutlinedIcon from "@material-ui/icons/SentimentVerySatisfiedOutlined";
-import SvgIcon from "@material-ui/core/SvgIcon";
-
-// Given a sentiment value in [-1, 1] return an appropriate Icon
-export function SentimentToIcon(sentiment) {
-    // neutral
-    if (Math.abs(sentiment) < 0.2) {
-        return (
-            <SvgIcon fontSize="large">
-                <path d="M9 14h6v1.5H9z" />
-                <circle cx="15.5" cy="9.5" r="1.5" />
-                <circle cx="8.5" cy="9.5" r="1.5" />
-                <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
-            </SvgIcon>
-        );
-    }
-    if (sentiment < 0) {
-        if (sentiment < -0.8) {
-            return <SentimentVeryDissatisfiedOutlinedIcon fontSize="large" />;
-        }
-        if (sentiment < -0.5) {
-            return <SentimentVeryDissatisfiedIcon fontSize="large" />;
-        }
-        return <SentimentDissatisfiedIcon fontSize="large" />;
-    } else {
-        if (sentiment > 0.8) {
-            return <SentimentVerySatisfiedOutlinedIcon fontSize="large" />;
-        }
-        if (sentiment > 0.5) {
-            return <SentimentVerySatisfiedIcon fontSize="large" />;
-        }
-        return <SentimentSatisfiedAltIcon fontSize="large" />;
-    }
-}
 
 // Client URL Constants
 export const DASHBOARD_URL = "/dashboard";

--- a/client/src/components/DashboardBody.js
+++ b/client/src/components/DashboardBody.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { Route } from "react-router-dom";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
 import Tab from "@material-ui/core/Tab";
 import { MENTIONS_ROUTE } from "../Routes";
 import Reddit from "../assets/reddit.png";
@@ -69,6 +70,38 @@ class DashboardBody extends Component {
             hasMore: true
         };
     }
+
+    // Find the company names using regex and bold them
+    boldNames = (reg, text) => {
+        // g = global flag, i = ignorecase flag
+        const regex = new RegExp(reg, "gi");
+        const matches = text.matchAll(regex);
+
+        // Collect the indices of the bold words
+        let Indices = [];
+        for (const match of matches) {
+            Indices.push(match.index);
+            Indices.push(match.index + match[0].length);
+        }
+
+        // Bold the words by wrapping a strong tag around them
+        let result = [];
+        let index = 0;
+        for (let i = 0; i < Indices.length; i += 2) {
+            // Push unbolded string
+            result.push(<React.Fragment key={i}>{text.substring(index, Indices[i])}</React.Fragment>);
+            // Push bolded name
+            result.push(
+                <Box component="strong" key={i + 1}>
+                    {text.substring(Indices[i], Indices[i + 1])}
+                </Box>
+            );
+            index = Indices[i + 1];
+        }
+        result.push(<React.Fragment key={-1}>{text.substring(index)}</React.Fragment>);
+        return result;
+    };
+
     fetchMentions = () => {
         const { page, mentions } = this.state;
         fetch(MENTIONS_ROUTE + "/" + page, { method: "GET", headers: { "Content-Type": "application/json" } }).then(res => {
@@ -143,6 +176,7 @@ class DashboardBody extends Component {
                         site={mention.site}
                         sentiment={mention.sentiment}
                         regex={reg}
+                        bold={this.boldNames}
                     />
                 );
             });
@@ -188,7 +222,14 @@ class DashboardBody extends Component {
 
                 <Route
                     path={`/dashboard/mention/:id`}
-                    component={props => <Dialog id={props.match.params.id} regex={globalRegex} history={props.history} />}
+                    component={props => (
+                        <Dialog
+                            id={props.match.params.id}
+                            regex={globalRegex}
+                            history={props.history}
+                            bold={this.boldNames}
+                        />
+                    )}
                 />
             </div>
         );

--- a/client/src/components/DashboardHead.js
+++ b/client/src/components/DashboardHead.js
@@ -1,0 +1,61 @@
+/* Component for rendering the dashboard header and tabs  */
+import React from "react";
+import { makeStyles } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
+import Tab from "@material-ui/core/Tab";
+
+const useStyles = makeStyles(theme => ({
+    top_section: {
+        display: "flex",
+        alignItems: "center",
+        width: "100%",
+        maxWidth: 800,
+        margin: `0 auto ${theme.spacing(4)}px auto`
+    },
+    mention_header: {
+        flexGrow: 1
+    },
+    mention_tabs: {
+        backgroundColor: theme.secondary,
+        // High border radius to give a 'pill' look
+        borderRadius: 500
+    },
+    mention_tab: {
+        borderRadius: 500
+    },
+    tab_active: {
+        backgroundColor: theme.primary,
+        color: "white"
+    },
+    tab_inactive: {
+        backgroundColor: "transparent",
+        color: theme.primary
+    }
+}));
+
+function DashboardHead(props) {
+    const classes = useStyles();
+    const { tab, click1, click2 } = props;
+
+    return (
+        <div className={classes.top_section}>
+            <Typography variant="h4" className={classes.mention_header}>
+                My Mentions
+            </Typography>
+            <div className={classes.mention_tabs}>
+                <Tab
+                    label="Most Recent"
+                    className={`${classes.mention_tab} ${tab === 0 ? classes.tab_active : classes.tab_inactive}`}
+                    onClick={click1}
+                />
+                <Tab
+                    label="Most Popular"
+                    className={`${classes.mention_tab} ${tab === 1 ? classes.tab_active : classes.tab_inactive}`}
+                    onClick={click2}
+                />
+            </div>
+        </div>
+    );
+}
+
+export default DashboardHead;

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -4,15 +4,15 @@
 import React, { Component } from "react";
 import { withStyles } from "@material-ui/core/styles";
 import { DIALOG_ROUTE } from "../Routes";
-import { RESPONSE_TAG, SentimentToIcon } from "../Constants";
+import { RESPONSE_TAG } from "../Constants";
 import Reddit from "../assets/reddit.png";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Paper from "@material-ui/core/Paper";
 import Link from "@material-ui/core/Link";
-import Tooltip from "@material-ui/core/Tooltip";
 import CallMadeIcon from "@material-ui/icons/CallMade";
 import { default as Modal } from "@material-ui/core/Dialog";
+import MentionContainer from "./MentionContainer";
+import MentionHeader from "./MentionHeader";
 
 // Map the name of a site to their logo image reference
 const SITE_TO_IMG = { Reddit };
@@ -34,23 +34,9 @@ const styles = theme => ({
         maxWidth: 1000,
         margin: "auto"
     },
-    image: {
-        width: 100,
-        height: 100
-    },
     info: {
         marginLeft: theme.spacing(2),
         maxWidth: 900
-    },
-    header: {
-        display: "flex"
-    },
-    title: {
-        flexGrow: 1,
-        marginRight: theme.spacing(1)
-    },
-    icon: {
-        color: theme.primary
     },
     snippet: {
         gridColumn: "span 2",
@@ -70,7 +56,7 @@ class Dialog extends Component {
         if (mention) {
             const snippet = mention.snippet.length !== 0 ? mention.snippet : NO_SNIPPET_MESSAGE;
             const snippetColor = mention.snippet.length !== 0 ? "initial" : "textSecondary";
-            const sentiment = Number(Number(mention.sentiment).toFixed(2));
+
             return (
                 <Modal
                     open={true}
@@ -80,24 +66,16 @@ class Dialog extends Component {
                     maxWidth="xl"
                     scroll="paper"
                 >
-                    <Paper className={classes.container}>
-                        <img src={SITE_TO_IMG[mention.site]} className={classes.image} alt="Thumbnail" />
-
+                    <MentionContainer container={classes.container} img={SITE_TO_IMG[mention.site]}>
                         <Box className={classes.info}>
-                            <Box className={classes.header}>
-                                <Typography variant="h4" noWrap className={classes.title}>
-                                    {bold(regex, mention.title)}
-                                </Typography>
-
-                                <Tooltip
-                                    title={`Score: ${Number(sentiment * 100).toFixed()}`}
-                                    placement="top"
-                                    aria-label="Sentiment score"
-                                    className={classes.icon}
-                                >
-                                    {SentimentToIcon(mention.sentiment)}
-                                </Tooltip>
-                            </Box>
+                            <MentionHeader
+                                variant="h4"
+                                noWrap={true}
+                                bold={bold}
+                                regex={regex}
+                                title={mention.title}
+                                sentiment={mention.sentiment}
+                            />
 
                             <Typography variant="h5" color="textSecondary">
                                 {mention.site}
@@ -117,7 +95,7 @@ class Dialog extends Component {
                                 {bold(regex, snippet)}
                             </Typography>
                         </Box>
-                    </Paper>
+                    </MentionContainer>
                 </Modal>
             );
         }
@@ -130,11 +108,11 @@ class Dialog extends Component {
                 maxWidth="xl"
                 scroll="paper"
             >
-                <Paper className={classes.simpleContainer}>
-                    <Typography variant="h5" align="center" color={"textSecondary"}>
+                <MentionContainer container={classes.simpleContainer}>
+                    <Typography variant="h5" color={"textSecondary"}>
                         {message}
                     </Typography>
-                </Paper>
+                </MentionContainer>
             </Modal>
         );
     }

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -54,7 +54,7 @@ class Dialog extends Component {
         this.props.history.push(DASHBOARD_URL);
     };
     render() {
-        const { classes, regex, bold } = this.props;
+        const { classes, bold } = this.props;
         const { mention, message } = this.state;
 
         if (mention) {
@@ -70,7 +70,6 @@ class Dialog extends Component {
                                 variant="h4"
                                 noWrap={true}
                                 bold={bold}
-                                regex={regex}
                                 title={mention.title}
                                 sentiment={mention.sentiment}
                             />
@@ -85,7 +84,7 @@ class Dialog extends Component {
                         </Box>
 
                         <Box className={classes.snippet}>
-                            <MentionText variant="body1" color={snippetColor} bold={bold} regex={regex} text={snippet} />
+                            <MentionText variant="body1" color={snippetColor} bold={bold} text={snippet} />
                         </Box>
                     </MentionContainer>
                 </Modal>

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -4,15 +4,14 @@
 import React, { Component } from "react";
 import { withStyles } from "@material-ui/core/styles";
 import { DIALOG_ROUTE } from "../Routes";
-import { RESPONSE_TAG } from "../Constants";
+import { RESPONSE_TAG, DASHBOARD_URL } from "../Constants";
 import Reddit from "../assets/reddit.png";
-import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Link from "@material-ui/core/Link";
-import CallMadeIcon from "@material-ui/icons/CallMade";
 import { default as Modal } from "@material-ui/core/Dialog";
 import MentionContainer from "./MentionContainer";
 import MentionHeader from "./MentionHeader";
+import MentionInfo from "./MentionInfo";
+import MentionText from "./MentionText";
 
 // Map the name of a site to their logo image reference
 const SITE_TO_IMG = { Reddit };
@@ -29,6 +28,7 @@ const styles = theme => ({
     container: {
         display: "grid",
         gridTemplateColumns: "1fr 9fr",
+        gridGap: theme.spacing(2),
         padding: theme.spacing(4),
         width: "fit-content",
         maxWidth: 1000,
@@ -49,23 +49,21 @@ class Dialog extends Component {
         super(props);
         this.state = { id: props.id, mention: null, message: LOADING_MESSAGE };
     }
+
+    handleClose = () => {
+        this.props.history.push(DASHBOARD_URL);
+    };
     render() {
-        const { classes, regex, bold, history } = this.props;
+        const { classes, regex, bold } = this.props;
         const { mention, message } = this.state;
 
         if (mention) {
             const snippet = mention.snippet.length !== 0 ? mention.snippet : NO_SNIPPET_MESSAGE;
             const snippetColor = mention.snippet.length !== 0 ? "initial" : "textSecondary";
+            const { site, hits, url } = mention;
 
             return (
-                <Modal
-                    open={true}
-                    onClose={() => {
-                        history.push("/dashboard");
-                    }}
-                    maxWidth="xl"
-                    scroll="paper"
-                >
+                <Modal open={true} onClose={this.handleClose} maxWidth="xl" scroll="paper">
                     <MentionContainer container={classes.container} img={SITE_TO_IMG[mention.site]}>
                         <Box className={classes.info}>
                             <MentionHeader
@@ -76,42 +74,27 @@ class Dialog extends Component {
                                 title={mention.title}
                                 sentiment={mention.sentiment}
                             />
-
-                            <Typography variant="h5" color="textSecondary">
-                                {mention.site}
-                            </Typography>
-                            <Typography variant="h5" color="textSecondary">
-                                Hits: {mention.hits}
-                            </Typography>
-                            <Link href={mention.url} variant="h5">
-                                Source <CallMadeIcon />
-                            </Link>
-                            <br></br>
-                            <br></br>
+                            <MentionInfo
+                                siteVariant="h5"
+                                site={site}
+                                hitsVariant="h5"
+                                hits={hits}
+                                url={url}
+                                urlVariant="h5"
+                            />
                         </Box>
 
                         <Box className={classes.snippet}>
-                            <Typography variant="body1" color={snippetColor}>
-                                {bold(regex, snippet)}
-                            </Typography>
+                            <MentionText variant="body1" color={snippetColor} bold={bold} regex={regex} text={snippet} />
                         </Box>
                     </MentionContainer>
                 </Modal>
             );
         }
         return (
-            <Modal
-                open={true}
-                onClose={() => {
-                    this.props.history.push("/dashboard");
-                }}
-                maxWidth="xl"
-                scroll="paper"
-            >
+            <Modal open={true} onClose={this.handleClose} maxWidth="xl" scroll="paper">
                 <MentionContainer container={classes.simpleContainer}>
-                    <Typography variant="h5" color={"textSecondary"}>
-                        {message}
-                    </Typography>
+                    <MentionText variant="h5" color="textSecondary" text={message} />
                 </MentionContainer>
             </Modal>
         );

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -12,7 +12,6 @@ import Paper from "@material-ui/core/Paper";
 import Link from "@material-ui/core/Link";
 import Tooltip from "@material-ui/core/Tooltip";
 import CallMadeIcon from "@material-ui/icons/CallMade";
-import { boldNames } from "./Mention";
 import { default as Modal } from "@material-ui/core/Dialog";
 
 // Map the name of a site to their logo image reference
@@ -65,19 +64,18 @@ class Dialog extends Component {
         this.state = { id: props.id, mention: null, message: LOADING_MESSAGE };
     }
     render() {
-        const { classes } = this.props;
+        const { classes, regex, bold, history } = this.props;
         const { mention, message } = this.state;
 
         if (mention) {
             const snippet = mention.snippet.length !== 0 ? mention.snippet : NO_SNIPPET_MESSAGE;
             const snippetColor = mention.snippet.length !== 0 ? "initial" : "textSecondary";
             const sentiment = Number(Number(mention.sentiment).toFixed(2));
-            const regex = this.props.regex;
             return (
                 <Modal
                     open={true}
                     onClose={() => {
-                        this.props.history.push("/dashboard");
+                        history.push("/dashboard");
                     }}
                     maxWidth="xl"
                     scroll="paper"
@@ -88,7 +86,7 @@ class Dialog extends Component {
                         <Box className={classes.info}>
                             <Box className={classes.header}>
                                 <Typography variant="h4" noWrap className={classes.title}>
-                                    {boldNames(regex, mention.title)}
+                                    {bold(regex, mention.title)}
                                 </Typography>
 
                                 <Tooltip
@@ -116,7 +114,7 @@ class Dialog extends Component {
 
                         <Box className={classes.snippet}>
                             <Typography variant="body1" color={snippetColor}>
-                                {boldNames(regex, snippet)}
+                                {bold(regex, snippet)}
                             </Typography>
                         </Box>
                     </Paper>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -39,40 +39,10 @@ const useStyles = makeStyles(theme => ({
     }
 }));
 
-export function boldNames(reg, text) {
-    // g = global flag, i = ignorecase flag
-    const regex = new RegExp(reg, "gi");
-    const matches = text.matchAll(regex);
-
-    // Collect the indices of the bold words
-    let Indices = [];
-    for (const match of matches) {
-        Indices.push(match.index);
-        Indices.push(match.index + match[0].length);
-    }
-
-    // Bold the words by wrapping a strong tag around them
-    let result = [];
-    let index = 0;
-    for (let i = 0; i < Indices.length; i += 2) {
-        // Push unbolded string
-        result.push(<React.Fragment key={i}>{text.substring(index, Indices[i])}</React.Fragment>);
-        // Push bolded name
-        result.push(
-            <Box component="strong" key={i + 1}>
-                {text.substring(Indices[i], Indices[i + 1])}
-            </Box>
-        );
-        index = Indices[i + 1];
-    }
-    result.push(<React.Fragment key={-1}>{text.substring(index)}</React.Fragment>);
-    return result;
-}
-
 function Mention(props) {
     const classes = useStyles();
     const sentiment = Number(Number(props.sentiment).toFixed(2));
-    const { id, img, regex, title, site, snippet } = props;
+    const { id, img, regex, title, site, snippet, bold } = props;
 
     return (
         <Link to={`dashboard/mention/${id}`} style={{ textDecoration: "none", width: "100%" }}>
@@ -82,7 +52,7 @@ function Mention(props) {
                 <Box className={classes.text}>
                     <Box className={classes.header}>
                         <Typography variant="body1" className={classes.title}>
-                            {boldNames(regex, title)}
+                            {bold(regex, title)}
                         </Typography>
 
                         <Tooltip
@@ -98,7 +68,7 @@ function Mention(props) {
                         {site}
                     </Typography>
                     <Typography variant="caption" color="textSecondary">
-                        {boldNames(regex, snippet)}
+                        {bold(regex, snippet)}
                     </Typography>
                 </Box>
             </Paper>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -29,22 +29,15 @@ const useStyles = makeStyles(theme => ({
 
 function Mention(props) {
     const classes = useStyles();
-    const { id, img, regex, title, site, snippet, bold, sentiment } = props;
+    const { id, img, title, site, snippet, bold, sentiment } = props;
 
     return (
         <Link to={`${DASHBOARD_URL}/mention/${id}`} style={{ textDecoration: "none", width: "100%" }}>
             <MentionContainer container={classes.container} img={img}>
                 <Box className={classes.text}>
-                    <MentionHeader
-                        variant="body1"
-                        noWrap={false}
-                        bold={bold}
-                        regex={regex}
-                        title={title}
-                        sentiment={sentiment}
-                    />
+                    <MentionHeader variant="body1" noWrap={false} bold={bold} title={title} sentiment={sentiment} />
                     <MentionInfo siteVariant="body2" site={site} />
-                    <MentionText variant="caption" color="textSecondary" bold={bold} regex={regex} text={snippet} />
+                    <MentionText variant="caption" color="textSecondary" bold={bold} text={snippet} />
                 </Box>
             </MentionContainer>
         </Link>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -5,10 +5,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
-import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import MentionContainer from "./MentionContainer";
 import MentionHeader from "./MentionHeader";
+import MentionInfo from "./MentionInfo";
+import MentionText from "./MentionText";
+import { DASHBOARD_URL } from "../Constants";
 
 const useStyles = makeStyles(theme => ({
     container: {
@@ -30,7 +32,7 @@ function Mention(props) {
     const { id, img, regex, title, site, snippet, bold, sentiment } = props;
 
     return (
-        <Link to={`dashboard/mention/${id}`} style={{ textDecoration: "none", width: "100%" }}>
+        <Link to={`${DASHBOARD_URL}/mention/${id}`} style={{ textDecoration: "none", width: "100%" }}>
             <MentionContainer container={classes.container} img={img}>
                 <Box className={classes.text}>
                     <MentionHeader
@@ -41,12 +43,8 @@ function Mention(props) {
                         title={title}
                         sentiment={sentiment}
                     />
-                    <Typography variant="body2" color="textSecondary">
-                        {site}
-                    </Typography>
-                    <Typography variant="caption" color="textSecondary">
-                        {bold(regex, snippet)}
-                    </Typography>
+                    <MentionInfo siteVariant="body2" site={site} />
+                    <MentionText variant="caption" color="textSecondary" bold={bold} regex={regex} text={snippet} />
                 </Box>
             </MentionContainer>
         </Link>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -7,31 +7,17 @@ import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Paper from "@material-ui/core/Paper";
-import Tooltip from "@material-ui/core/Tooltip";
-import { SentimentToIcon } from "../Constants";
+import MentionContainer from "./MentionContainer";
+import MentionHeader from "./MentionHeader";
 
 const useStyles = makeStyles(theme => ({
-    card: {
+    container: {
         display: "flex",
         padding: theme.spacing(2),
         width: "100%",
         boxSizing: "border-box"
     },
-    header: {
-        display: "flex"
-    },
-    title: {
-        flexGrow: 1,
-        marginRight: theme.spacing(1)
-    },
-    icon: {
-        color: theme.primary
-    },
-    image: {
-        width: 100,
-        height: 100
-    },
+
     text: {
         marginLeft: theme.spacing(2),
         wordBreak: "break-word",
@@ -41,29 +27,20 @@ const useStyles = makeStyles(theme => ({
 
 function Mention(props) {
     const classes = useStyles();
-    const sentiment = Number(Number(props.sentiment).toFixed(2));
-    const { id, img, regex, title, site, snippet, bold } = props;
+    const { id, img, regex, title, site, snippet, bold, sentiment } = props;
 
     return (
         <Link to={`dashboard/mention/${id}`} style={{ textDecoration: "none", width: "100%" }}>
-            <Paper className={classes.card}>
-                <img src={img} className={classes.image} alt="Thumbnail" />
-
+            <MentionContainer container={classes.container} img={img}>
                 <Box className={classes.text}>
-                    <Box className={classes.header}>
-                        <Typography variant="body1" className={classes.title}>
-                            {bold(regex, title)}
-                        </Typography>
-
-                        <Tooltip
-                            title={`Score: ${Number(sentiment * 100).toFixed()}`}
-                            placement="top"
-                            aria-label="Sentiment score"
-                            className={classes.icon}
-                        >
-                            {SentimentToIcon(sentiment)}
-                        </Tooltip>
-                    </Box>
+                    <MentionHeader
+                        variant="body1"
+                        noWrap={false}
+                        bold={bold}
+                        regex={regex}
+                        title={title}
+                        sentiment={sentiment}
+                    />
                     <Typography variant="body2" color="textSecondary">
                         {site}
                     </Typography>
@@ -71,7 +48,7 @@ function Mention(props) {
                         {bold(regex, snippet)}
                     </Typography>
                 </Box>
-            </Paper>
+            </MentionContainer>
         </Link>
     );
 }

--- a/client/src/components/MentionContainer.js
+++ b/client/src/components/MentionContainer.js
@@ -1,0 +1,24 @@
+/* Component for rendering the container of a mention and its thumbnail */
+import React from "react";
+import { Paper } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+    image: {
+        width: 100,
+        height: 100
+    }
+}));
+
+function MentionContainer(props) {
+    const classes = useStyles();
+    const { container, img, children } = props;
+    return (
+        <Paper className={container}>
+            {img && <img src={img} alt="Thumbnail" className={classes.image} />}
+            {children}
+        </Paper>
+    );
+}
+
+export default MentionContainer;

--- a/client/src/components/MentionHeader.js
+++ b/client/src/components/MentionHeader.js
@@ -1,0 +1,77 @@
+/* Component for rendering the title and sentiment icon of a mention */
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import Tooltip from "@material-ui/core/Tooltip";
+import SentimentVeryDissatisfiedOutlinedIcon from "@material-ui/icons/SentimentVeryDissatisfiedOutlined";
+import SentimentVeryDissatisfiedIcon from "@material-ui/icons/SentimentVeryDissatisfied";
+import SentimentDissatisfiedIcon from "@material-ui/icons/SentimentDissatisfied";
+import SentimentSatisfiedAltIcon from "@material-ui/icons/SentimentSatisfiedAlt";
+import SentimentVerySatisfiedIcon from "@material-ui/icons/SentimentVerySatisfied";
+import SentimentVerySatisfiedOutlinedIcon from "@material-ui/icons/SentimentVerySatisfiedOutlined";
+import SvgIcon from "@material-ui/core/SvgIcon";
+
+// Given a sentiment value in [-1, 1] return an appropriate Icon
+function SentimentToIcon(sentiment) {
+    // neutral
+    if (Math.abs(sentiment) < 0.2) {
+        return (
+            <SvgIcon fontSize="large">
+                <path d="M9 14h6v1.5H9z" />
+                <circle cx="15.5" cy="9.5" r="1.5" />
+                <circle cx="8.5" cy="9.5" r="1.5" />
+                <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
+            </SvgIcon>
+        );
+    }
+    if (sentiment < 0) {
+        if (sentiment < -0.8) {
+            return <SentimentVeryDissatisfiedOutlinedIcon fontSize="large" />;
+        }
+        if (sentiment < -0.5) {
+            return <SentimentVeryDissatisfiedIcon fontSize="large" />;
+        }
+        return <SentimentDissatisfiedIcon fontSize="large" />;
+    } else {
+        if (sentiment > 0.8) {
+            return <SentimentVerySatisfiedOutlinedIcon fontSize="large" />;
+        }
+        if (sentiment > 0.5) {
+            return <SentimentVerySatisfiedIcon fontSize="large" />;
+        }
+        return <SentimentSatisfiedAltIcon fontSize="large" />;
+    }
+}
+
+const useStyles = makeStyles(theme => ({
+    header: {
+        display: "flex"
+    },
+    title: {
+        flexGrow: 1,
+        marginRight: theme.spacing(1)
+    },
+    icon: {
+        color: theme.primary
+    }
+}));
+
+function MentionHeader(props) {
+    const classes = useStyles();
+    const sentiment = Number(props.sentiment * 100).toFixed(2);
+    const { regex, title, bold, variant, noWrap } = props;
+    return (
+        <Box className={classes.header}>
+            <Typography variant={variant} noWrap={noWrap} className={classes.title}>
+                {bold(regex, title)}
+            </Typography>
+
+            <Tooltip title={`Score: ${sentiment}`} placement="top" aria-label="Sentiment score" className={classes.icon}>
+                {SentimentToIcon(props.sentiment)}
+            </Tooltip>
+        </Box>
+    );
+}
+
+export default MentionHeader;

--- a/client/src/components/MentionHeader.js
+++ b/client/src/components/MentionHeader.js
@@ -60,11 +60,11 @@ const useStyles = makeStyles(theme => ({
 function MentionHeader(props) {
     const classes = useStyles();
     const sentiment = Number(props.sentiment * 100).toFixed(2);
-    const { regex, title, bold, variant, noWrap } = props;
+    const { title, bold, variant, noWrap } = props;
     return (
         <Box className={classes.header}>
             <Typography variant={variant} noWrap={noWrap} className={classes.title}>
-                {bold(regex, title)}
+                {bold(title)}
             </Typography>
 
             <Tooltip title={`Score: ${sentiment}`} placement="top" aria-label="Sentiment score" className={classes.icon}>

--- a/client/src/components/MentionInfo.js
+++ b/client/src/components/MentionInfo.js
@@ -1,0 +1,28 @@
+/* Component for rendering the details of a mention such as the source or popularity */
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+import Link from "@material-ui/core/Link";
+import CallMadeIcon from "@material-ui/icons/CallMade";
+
+function MentionInfo(props) {
+    const { siteVariant, site, hits, hitsVariant, url, urlVariant } = props;
+    return (
+        <React.Fragment>
+            <Typography variant={siteVariant} color="textSecondary">
+                {site}
+            </Typography>
+            {hits && (
+                <Typography variant={hitsVariant} color="textSecondary">
+                    Hits: {hits}
+                </Typography>
+            )}
+            {url && (
+                <Link href={url} variant={urlVariant} target="_blank">
+                    Source <CallMadeIcon />
+                </Link>
+            )}
+        </React.Fragment>
+    );
+}
+
+export default MentionInfo;

--- a/client/src/components/MentionText.js
+++ b/client/src/components/MentionText.js
@@ -3,10 +3,10 @@ import React from "react";
 import Typography from "@material-ui/core/Typography";
 
 function MentionText(props) {
-    const { variant, color, bold, regex, text } = props;
+    const { variant, color, bold, text } = props;
     return (
         <Typography variant={variant} color={color}>
-            {bold ? bold(regex, text) : text}
+            {bold ? bold(text) : text}
         </Typography>
     );
 }

--- a/client/src/components/MentionText.js
+++ b/client/src/components/MentionText.js
@@ -1,0 +1,14 @@
+/* Component for rendering the main text(snippet or info message) of a mention */
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+
+function MentionText(props) {
+    const { variant, color, bold, regex, text } = props;
+    return (
+        <Typography variant={variant} color={color}>
+            {bold ? bold(regex, text) : text}
+        </Typography>
+    );
+}
+
+export default MentionText;

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -20,21 +20,22 @@ function Dashboard() {
 
     if (localStorage.getItem(COMPANY_NAMES_TAG) && localStorage.getItem(EMAIL_TAG) && localStorage.getItem(SITES_TAG)) {
         // Insert Socket connection here
-    } else {
-        return <Redirect to={LOGIN_URL} />;
+
+        const names = localStorage.getItem(COMPANY_NAMES_TAG).split(",");
+        return (
+            <React.Fragment>
+                <ServiceNavBar link={SETTINGS_URL}>
+                    <SettingsIcon fontSize="large" />
+                </ServiceNavBar>
+                <div className={classes.mentions_layout}>
+                    <DashboardSideBar />
+                    <DashboardBody names={names} />
+                </div>
+            </React.Fragment>
+        );
     }
 
-    return (
-        <React.Fragment>
-            <ServiceNavBar link={SETTINGS_URL}>
-                <SettingsIcon fontSize="large" />
-            </ServiceNavBar>
-            <div className={classes.mentions_layout}>
-                <DashboardSideBar />
-                <DashboardBody />
-            </div>
-        </React.Fragment>
-    );
+    return <Redirect to={LOGIN_URL} />;
 }
 
 export default Dashboard;


### PR DESCRIPTION
I ended up doing a bit more than component reusing
-Added 4 subcomponents for reuse in Dialog and Mention
-Moved all the sentiment logic from Constants.js to MentionHeader.js
-The function used to bold company names is now passed down from DashboardBody to Mention and Dialog instead of being exported

-Added boolean to DashboardBody to keep track of whether it has fetched mentions or not
-Dialog is conditionally rendered on the new boolean
Reason I did this is because when a user goes directly to the dialog url, a refresh occurs due to state change which is slightly annoying.

-Made a new component to render the dashboard tabs
-Also changed some text to appropriate constants