### PR TITLE
Company Name Prefixing and More Favourite Functionality

### DIFF
--- a/client/src/components/DashboardBody.js
+++ b/client/src/components/DashboardBody.js
@@ -155,6 +155,7 @@ class DashboardBody extends Component {
                 // summarize long snippets and titles
                 let snippet = this.summarizeString(mention.snippet, MAX_SNIPPET_CHARACTERS);
                 let title = this.summarizeString(mention.title, MAX_TITLE_CHARACTERS);
+
                 renderMentions.push(
                     <Mention
                         key={key}
@@ -169,6 +170,7 @@ class DashboardBody extends Component {
                         favourite={mention.favourite}
                         history={history}
                         unmount={this.deleteMention(mention.id)}
+                        handleFavourite={value => this.favouriteMention(mention.id, value)}
                     />
                 );
             });
@@ -219,16 +221,16 @@ class DashboardBody extends Component {
         this.setState({ mentions: { ...this.state.mentions } });
     };
 
-    favouriteMention = () => {
-        const newMention = this.state.mentions[this.props.favouriteID];
+    favouriteMention = (id = this.props.favouriteID, value = this.props.favouriteValue) => {
+        const newMention = this.state.mentions[id];
         if (newMention) {
-            newMention.favourite = this.props.favouriteValue;
-            this.setState({ mentions: { ...this.state.mentions } });
+            newMention.favourite = value;
+            this.forceUpdate();
         }
     };
 
     shouldComponentUpdate(nextProps, nextState) {
-        const { searchString, platformFilters, nameFilters, deleteID, favouriteID, favouriteValue } = this.props;
+        const { searchString, platformFilters, nameFilters, deleteID, favouriteTrigger } = this.props;
         const { tabValue, page, sort, mentions, hasMore } = this.state;
 
         return (
@@ -236,8 +238,7 @@ class DashboardBody extends Component {
             nextProps.platformFilters !== platformFilters ||
             nextProps.nameFilters !== nameFilters ||
             nextProps.deleteID !== deleteID ||
-            nextProps.favouriteID !== favouriteID ||
-            nextProps.favouriteValue !== favouriteValue ||
+            nextProps.favouriteTrigger !== favouriteTrigger ||
             nextState.tabValue !== tabValue ||
             nextState.page !== page ||
             nextState.sort !== sort ||
@@ -295,7 +296,7 @@ class DashboardBody extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { searchString, platformFilters, nameFilters, deleteID, favouriteID, favouriteValue } = this.props;
+        const { searchString, platformFilters, nameFilters, deleteID, favouriteTrigger } = this.props;
         if (
             prevProps.searchString !== searchString ||
             prevProps.platformFilters !== platformFilters ||
@@ -304,7 +305,7 @@ class DashboardBody extends Component {
             this.setState({ page: 1, mentions: [], hasMore: true }, () => this.fetchMentions(false));
         } else if (prevProps.deleteID !== deleteID) {
             this.deleteMention(deleteID)();
-        } else if (prevProps.favouriteID !== favouriteID || prevProps.favouriteValue !== favouriteValue) {
+        } else if (prevProps.favouriteTrigger !== favouriteTrigger) {
             this.favouriteMention();
         }
     }

--- a/client/src/components/DashboardBody.js
+++ b/client/src/components/DashboardBody.js
@@ -219,14 +219,25 @@ class DashboardBody extends Component {
         this.setState({ mentions: { ...this.state.mentions } });
     };
 
+    favouriteMention = () => {
+        const newMention = this.state.mentions[this.props.favouriteID];
+        if (newMention) {
+            newMention.favourite = this.props.favouriteValue;
+            this.setState({ mentions: { ...this.state.mentions } });
+        }
+    };
+
     shouldComponentUpdate(nextProps, nextState) {
-        const { searchString, platformFilters, nameFilters } = this.props;
+        const { searchString, platformFilters, nameFilters, deleteID, favouriteID, favouriteValue } = this.props;
         const { tabValue, page, sort, mentions, hasMore } = this.state;
 
         return (
             nextProps.searchString !== searchString ||
             nextProps.platformFilters !== platformFilters ||
             nextProps.nameFilters !== nameFilters ||
+            nextProps.deleteID !== deleteID ||
+            nextProps.favouriteID !== favouriteID ||
+            nextProps.favouriteValue !== favouriteValue ||
             nextState.tabValue !== tabValue ||
             nextState.page !== page ||
             nextState.sort !== sort ||
@@ -284,12 +295,17 @@ class DashboardBody extends Component {
     }
 
     componentDidUpdate(prevProps) {
+        const { searchString, platformFilters, nameFilters, deleteID, favouriteID, favouriteValue } = this.props;
         if (
-            prevProps.searchString !== this.props.searchString ||
-            prevProps.platformFilters !== this.props.platformFilters ||
-            prevProps.nameFilters !== this.props.nameFilters
+            prevProps.searchString !== searchString ||
+            prevProps.platformFilters !== platformFilters ||
+            prevProps.nameFilters !== nameFilters
         ) {
             this.setState({ page: 1, mentions: [], hasMore: true }, () => this.fetchMentions(false));
+        } else if (prevProps.deleteID !== deleteID) {
+            this.deleteMention(deleteID)();
+        } else if (prevProps.favouriteID !== favouriteID || prevProps.favouriteValue !== favouriteValue) {
+            this.favouriteMention();
         }
     }
 

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -50,9 +50,12 @@ class Dialog extends Component {
         this.props.history.push(DASHBOARD_URL);
     };
 
-    shouldComponentUpdate() {
-        return !this.state.mention;
+    shouldComponentUpdate(nextProps, nextState) {
+        return !this.state.mention || this.state.message !== nextState.message;
     }
+
+    // When the mentions gets deleted due to an unfavourite
+    handleDelete = () => this.setState({ mention: null, message: NOT_FOUND_MESSAGE });
 
     render() {
         const { classes, bold, history, id } = this.props;
@@ -74,6 +77,7 @@ class Dialog extends Component {
                                 id={id}
                                 sentiment={sentiment}
                                 favourite={mention.favourite}
+                                unmount={this.handleDelete}
                             />
                             <MentionInfo
                                 site={site}

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -43,7 +43,7 @@ const styles = theme => ({
 class Dialog extends Component {
     constructor(props) {
         super(props);
-        this.state = { id: props.id, mention: null, message: LOADING_MESSAGE };
+        this.state = { mention: null, message: LOADING_MESSAGE };
     }
 
     handleClose = () => {
@@ -55,7 +55,14 @@ class Dialog extends Component {
     }
 
     // When the mentions gets deleted due to an unfavourite
-    handleDelete = () => this.setState({ mention: null, message: NOT_FOUND_MESSAGE });
+    handleDelete = () => {
+        this.handleClose();
+        this.props.delete(this.props.id);
+    };
+
+    handleFavourite = value => {
+        this.props.favourite([this.props.id, value]);
+    };
 
     render() {
         const { classes, bold, history, id } = this.props;
@@ -78,6 +85,7 @@ class Dialog extends Component {
                                 sentiment={sentiment}
                                 favourite={mention.favourite}
                                 unmount={this.handleDelete}
+                                handleFavourite={this.handleFavourite}
                             />
                             <MentionInfo
                                 site={site}
@@ -110,7 +118,7 @@ class Dialog extends Component {
     }
 
     componentDidMount() {
-        fetch(DIALOG_ROUTE + this.state.id, {
+        fetch(DIALOG_ROUTE + this.props.id, {
             method: "GET",
             headers: { "Content-Type": "application/json" }
         }).then(res => {

--- a/client/src/components/Dialog.js
+++ b/client/src/components/Dialog.js
@@ -51,7 +51,11 @@ class Dialog extends Component {
     };
 
     shouldComponentUpdate(nextProps, nextState) {
-        return !this.state.mention || this.state.message !== nextState.message;
+        return (
+            !this.state.mention ||
+            this.state.mention.favourite !== nextState.mention.favourite ||
+            this.state.message !== nextState.message
+        );
     }
 
     // When the mentions gets deleted due to an unfavourite
@@ -61,7 +65,8 @@ class Dialog extends Component {
     };
 
     handleFavourite = value => {
-        this.props.favourite([this.props.id, value]);
+        this.setState({ mention: { ...this.state.mention, favourite: value } });
+        this.props.favourite([this.props.id, value, !this.props.favouriteTrigger]);
     };
 
     render() {

--- a/client/src/components/FavouriteIcon.js
+++ b/client/src/components/FavouriteIcon.js
@@ -25,9 +25,8 @@ const useStyles = makeStyles(theme => ({
 
 function FavouriteIcon(props) {
     const classes = useStyles();
-    const { favourite, id, history } = props;
+    const { favourite, id, history, unmount } = props;
     const [favourited, setfavourited] = useState(favourite);
-
     const handleClick = e => {
         e.preventDefault();
         fetch(`${FAVOURITE_ROUTE}${id}`, {
@@ -38,9 +37,7 @@ function FavouriteIcon(props) {
                 localStorage.clear();
                 history.push(LOGIN_URL);
             } else if (res.ok) {
-                res.json().then(data => {
-                    setfavourited(data.favourite);
-                });
+                res.json().then(data => (data.deleted ? unmount() : setfavourited(data.favourite)));
             } else {
                 res.json().then(data => console.log(data));
             }

--- a/client/src/components/FavouriteIcon.js
+++ b/client/src/components/FavouriteIcon.js
@@ -1,5 +1,5 @@
 /* Component for rendering the favourite icon of a mention */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { default as FavIcon } from "@material-ui/icons/Favorite";
 import FavoriteBorderIcon from "@material-ui/icons/FavoriteBorder";
@@ -25,8 +25,13 @@ const useStyles = makeStyles(theme => ({
 
 function FavouriteIcon(props) {
     const classes = useStyles();
-    const { favourite, id, history, unmount } = props;
+    const { favourite, id, history, unmount, handleFavourite } = props;
     const [favourited, setfavourited] = useState(favourite);
+
+    useEffect(() => {
+        setfavourited(favourite);
+    }, [favourite]);
+
     const handleClick = e => {
         e.preventDefault();
         fetch(`${FAVOURITE_ROUTE}${id}`, {
@@ -37,7 +42,14 @@ function FavouriteIcon(props) {
                 localStorage.clear();
                 history.push(LOGIN_URL);
             } else if (res.ok) {
-                res.json().then(data => (data.deleted ? unmount() : setfavourited(data.favourite)));
+                res.json().then(data => {
+                    if (data.deleted) {
+                        unmount();
+                    } else {
+                        setfavourited(data.favourite);
+                        handleFavourite && handleFavourite(data.favourite);
+                    }
+                });
             } else {
                 res.json().then(data => console.log(data));
             }

--- a/client/src/components/FavouriteIcon.js
+++ b/client/src/components/FavouriteIcon.js
@@ -1,5 +1,5 @@
 /* Component for rendering the favourite icon of a mention */
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { default as FavIcon } from "@material-ui/icons/Favorite";
 import FavoriteBorderIcon from "@material-ui/icons/FavoriteBorder";
@@ -26,11 +26,6 @@ const useStyles = makeStyles(theme => ({
 function FavouriteIcon(props) {
     const classes = useStyles();
     const { favourite, id, history, unmount, handleFavourite } = props;
-    const [favourited, setfavourited] = useState(favourite);
-
-    useEffect(() => {
-        setfavourited(favourite);
-    }, [favourite]);
 
     const handleClick = e => {
         e.preventDefault();
@@ -46,8 +41,7 @@ function FavouriteIcon(props) {
                     if (data.deleted) {
                         unmount();
                     } else {
-                        setfavourited(data.favourite);
-                        handleFavourite && handleFavourite(data.favourite);
+                        handleFavourite(data.favourite);
                     }
                 });
             } else {
@@ -56,7 +50,7 @@ function FavouriteIcon(props) {
         });
     };
 
-    if (favourited) {
+    if (favourite) {
         return <FavIcon fontSize="large" className={`${classes.favourited} ${classes.icon}`} onClick={handleClick} />;
     }
     return <FavoriteBorderIcon fontSize="large" className={`${classes.favourite} ${classes.icon}`} onClick={handleClick} />;

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
 
 function Mention(props) {
     const classes = useStyles();
-    const { id, img, title, site, snippet, bold, sentiment, date, favourite, history } = props;
+    const { id, img, title, site, snippet, bold, sentiment, date, favourite, history, unmount } = props;
 
     return (
         <Link to={`${DASHBOARD_URL}/mention/${id}`} className={classes.link}>
@@ -54,6 +54,7 @@ function Mention(props) {
                         history={history}
                         date={date}
                         dateVariant="body2"
+                        unmount={unmount}
                     />
                     <MentionText variant="caption" bold={bold} text={snippet} />
                 </Box>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
 
 function Mention(props) {
     const classes = useStyles();
-    const { id, img, title, site, snippet, bold, sentiment, date, favourite, history, unmount } = props;
+    const { id, img, title, site, snippet, bold, sentiment, date, favourite, history, unmount, handleFavourite } = props;
 
     return (
         <Link to={`${DASHBOARD_URL}/mention/${id}`} className={classes.link}>
@@ -55,6 +55,7 @@ function Mention(props) {
                         date={date}
                         dateVariant="body2"
                         unmount={unmount}
+                        handleFavourite={handleFavourite}
                     />
                     <MentionText variant="caption" bold={bold} text={snippet} />
                 </Box>

--- a/client/src/components/Mention.js
+++ b/client/src/components/Mention.js
@@ -63,4 +63,4 @@ function Mention(props) {
     );
 }
 
-export default React.memo(Mention, (prev, next) => prev.id === next.id);
+export default React.memo(Mention, (prev, next) => prev.id === next.id && prev.favourite === next.favourite);

--- a/client/src/components/MentionHeader.js
+++ b/client/src/components/MentionHeader.js
@@ -63,7 +63,7 @@ const useStyles = makeStyles(theme => ({
 function MentionHeader(props) {
     const classes = useStyles();
     const sentiment = Number(props.sentiment * 100).toFixed(2);
-    const { title, bold, titleVariant, site, siteVariant, dateVariant, favourite, id, history } = props;
+    const { title, bold, titleVariant, site, siteVariant, dateVariant, favourite, id, history, unmount } = props;
     const date = props.date && GET_DATE_STRING(new Date(props.date * 1000));
 
     return (
@@ -77,7 +77,13 @@ function MentionHeader(props) {
                     {date}
                 </Typography>
             </Box>
-            <FavouriteIcon className={classes.favourite_icon} favourite={favourite} id={id} history={history} />
+            <FavouriteIcon
+                className={classes.favourite_icon}
+                favourite={favourite}
+                id={id}
+                history={history}
+                unmount={unmount}
+            />
             <Tooltip
                 title={`Score: ${sentiment}`}
                 placement="top"

--- a/client/src/components/MentionHeader.js
+++ b/client/src/components/MentionHeader.js
@@ -63,7 +63,19 @@ const useStyles = makeStyles(theme => ({
 function MentionHeader(props) {
     const classes = useStyles();
     const sentiment = Number(props.sentiment * 100).toFixed(2);
-    const { title, bold, titleVariant, site, siteVariant, dateVariant, favourite, id, history, unmount } = props;
+    const {
+        title,
+        bold,
+        titleVariant,
+        site,
+        siteVariant,
+        dateVariant,
+        favourite,
+        id,
+        history,
+        unmount,
+        handleFavourite
+    } = props;
     const date = props.date && GET_DATE_STRING(new Date(props.date * 1000));
 
     return (
@@ -83,6 +95,7 @@ function MentionHeader(props) {
                 id={id}
                 history={history}
                 unmount={unmount}
+                handleFavourite={handleFavourite}
             />
             <Tooltip
                 title={`Score: ${sentiment}`}

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -44,6 +44,8 @@ function Dashboard(props) {
     const [open, setOpen] = useState(false);
     const [platformFilters, setPlatforms] = useState(initialPlatforms);
     const [nameFilters, setNames] = useState(initialNames);
+    const [deleteID, setDeleteID] = useState(-1);
+    const [favourite, setFavourite] = useState([-1, false]);
     const setFilters = (platforms, names) => {
         setPlatforms(platforms);
         setNames(names);
@@ -112,10 +114,21 @@ function Dashboard(props) {
                         searchString={searchString}
                         platformFilters={platformFilters}
                         nameFilters={nameFilters}
+                        deleteID={deleteID}
+                        favouriteID={favourite[0]}
+                        favouriteValue={favourite[1]}
                     />
                     <Route
                         path={`/dashboard/mention/:id`}
-                        component={props => <Dialog id={props.match.params.id} history={props.history} bold={boldNames} />}
+                        component={props => (
+                            <Dialog
+                                id={props.match.params.id}
+                                history={props.history}
+                                bold={boldNames}
+                                delete={setDeleteID}
+                                favourite={setFavourite}
+                            />
+                        )}
                     />
                 </div>
             </React.Fragment>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -45,7 +45,7 @@ function Dashboard(props) {
     const [platformFilters, setPlatforms] = useState(initialPlatforms);
     const [nameFilters, setNames] = useState(initialNames);
     const [deleteID, setDeleteID] = useState(-1);
-    const [favourite, setFavourite] = useState([-1, false]);
+    const [favourite, setFavourite] = useState([-1, false, false]);
     const setFilters = (platforms, names) => {
         setPlatforms(platforms);
         setNames(names);
@@ -117,16 +117,18 @@ function Dashboard(props) {
                         deleteID={deleteID}
                         favouriteID={favourite[0]}
                         favouriteValue={favourite[1]}
+                        favouriteTrigger={favourite[2]}
                     />
                     <Route
                         path={`/dashboard/mention/:id`}
-                        component={props => (
+                        render={props => (
                             <Dialog
                                 id={props.match.params.id}
                                 history={props.history}
                                 bold={boldNames}
                                 delete={setDeleteID}
                                 favourite={setFavourite}
+                                favouriteTrigger={favourite[2]}
                             />
                         )}
                     />

--- a/server/constants.py
+++ b/server/constants.py
@@ -23,6 +23,7 @@ PASSWORD_TAG = "password"
 TOKEN_TAG = "mentions_crawler_token"
 WARN_TAG = "warn"
 EMPTY_TAG = "empty"
+DELETED_TAG = "deleted"
 
 # Socket Event Constants
 UPDATE_EVENT_TAG = "update"


### PR DESCRIPTION
-Company names are now prefixed with "company_" in the route to prevent name conflicts

-Mentions that are unfavourited after a name remove will be unmounted in the dashboard and dialog
-Favouriting a mention from the dialog will now cause the corresponding mention on the dashboard to update its favourite icon if it exists
-Moved the logic from FavouriteIcon up to the Dashboard so that the favourite status can be properly tracked

-Fixed the unmounting of the dialog due to a state change in Dashboard (changed component to render in Route component)
-Also changed the mentions state variable in DashboardBody to be an object instead of an array


